### PR TITLE
fix startup error

### DIFF
--- a/ipfs-daemon/config.yaml
+++ b/ipfs-daemon/config.yaml
@@ -1,8 +1,9 @@
 name: "IPFS Daemon"
 description: "Add-on to run IPFS Daemon"
-version: "1.3.0"
+version: "1.3.1"
 slug: "ipfs-daemon"
 init: false
+startup: services
 host_network: true
 arch:
   - aarch64


### PR DESCRIPTION
Fix error when after power up PC ipfs addon doesn't start before robonomics integration